### PR TITLE
WP-8-customer-policy user edit removed and customer policy added

### DIFF
--- a/app/Http/Livewire/Core/Account/Index.php
+++ b/app/Http/Livewire/Core/Account/Index.php
@@ -24,18 +24,18 @@ class Index extends Component
         ],
     ];
 
-    public function render()
+    public function mount()
     {
         $this->authorize('viewAny', Account::class);
 
-        return $this->renderView('livewire.core.account.index');
-    }
-
-    public function mount()
-    {
         $this->account = new Account();
         $this->sx_accounts = SXAccount::all();
         $this->formInit();
+    }
+
+    public function render()
+    {
+        return $this->renderView('livewire.core.account.index');
     }
 
     public function create()

--- a/app/Http/Livewire/Core/Customer/Index.php
+++ b/app/Http/Livewire/Core/Customer/Index.php
@@ -4,9 +4,12 @@ namespace App\Http\Livewire\Core\Customer;
 
 use App\Http\Livewire\Component\Component;
 use App\Models\Core\Customer;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 
 class Index extends Component
 {
+    use AuthorizesRequests;
+
     public $account;
 
     public $addRecord = false;
@@ -25,6 +28,8 @@ class Index extends Component
 
     public function mount()
     {
+        $this->authorize('viewAny', Customer::class);
+
         $this->account = account();
     }
 

--- a/app/Http/Livewire/Core/Customer/Show.php
+++ b/app/Http/Livewire/Core/Customer/Show.php
@@ -13,11 +13,12 @@ use DateInterval;
 use DatePeriod;
 use DateTime;
 use Illuminate\Database\Query\JoinClause;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Jantinnerezo\LivewireAlert\LivewireAlert;
 
 class Show extends Component
 {
-    use HasTabs, LivewireAlert;
+    use AuthorizesRequests, HasTabs, LivewireAlert;
 
     public Customer $customer;
 
@@ -107,6 +108,8 @@ class Show extends Component
 
     public function mount()
     {
+        $this->authorize('view', $this->customer);
+
         $this->sro_customer = SROCustomer::where('sx_customer_id', $this->customer->sx_customer_number)->first();
         array_push($this->breadcrumbs, ['title' => $this->customer->name]);
     }

--- a/app/Http/Livewire/Core/Location/Index.php
+++ b/app/Http/Livewire/Core/Location/Index.php
@@ -35,15 +35,17 @@ class Index extends Component
         ],
     ];
 
+    public function mount()
+    {
+        $this->authorize('viewAny', Location::class);
+
+        $this->location = new Location();
+        $this->formInit();
+    }
+
     public function render()
     {
         return view('livewire.core.location.index');
-    }
-
-    public function mount()
-    {
-        $this->location = new Location();
-        $this->formInit();
     }
 
     public function create()

--- a/app/Http/Livewire/Core/Module/Index.php
+++ b/app/Http/Livewire/Core/Module/Index.php
@@ -20,16 +20,16 @@ class Index extends Component
         'closeModal',
     ];
 
-    public function render()
-    {
-        $this->authorize('view', Module::class);
-
-        return view('livewire.core.module.index');
-    }
-
     public function mount()
     {
+        $this->authorize('viewAny', Module::class);
+
         $this->modules = Module::get();
+    }
+
+    public function render()
+    {
+        return view('livewire.core.module.index');
     }
 
     public function toggleModule($module_id, $value)

--- a/app/Http/Livewire/Core/User/Index.php
+++ b/app/Http/Livewire/Core/User/Index.php
@@ -25,17 +25,17 @@ class Index extends Component
         ];
     }
 
-    public function render()
+    public function mount()
     {
         $this->authorize('viewAny', User::class);
 
-        return view('livewire.core.user.index')->extends('livewire-app');
-    }
-
-    public function mount()
-    {
         $this->formInit();
         $this->breadcrumbs = $this->breadcrumbs();
+    }
+
+    public function render()
+    {
+        return view('livewire.core.user.index')->extends('livewire-app');
     }
 
     public function create()

--- a/app/Http/Livewire/Core/User/Show.php
+++ b/app/Http/Livewire/Core/User/Show.php
@@ -44,20 +44,21 @@ class Show extends Component
         $this->breadcrumbs = $this->breadcrumbs();
 
         if (auth()->user()->can('users.manage')) {
-            $this->actionButtons = [
-                [
-                    'icon' => 'fa-edit',
-                    'color' => 'primary',
-                    'listener' => 'edit',
-                ],
-                [
-                    'icon' => 'fa-trash',
-                    'color' => 'danger',
-                    'confirm' => true,
-                    'confirm_header' => 'Confirm Delete',
-                    'listener' => 'deleteRecord',
-                ],
-            ];
+            // @TODO Remove after confirmation on WP-8 Remove User info Edit
+            // $this->actionButtons = [
+            //     [
+            //         'icon' => 'fa-edit',
+            //         'color' => 'primary',
+            //         'listener' => 'edit',
+            //     ],
+            //     [
+            //         'icon' => 'fa-trash',
+            //         'color' => 'danger',
+            //         'confirm' => true,
+            //         'confirm_header' => 'Confirm Delete',
+            //         'listener' => 'deleteRecord',
+            //     ],
+            // ];
         }
     }
 
@@ -66,31 +67,33 @@ class Show extends Component
         return view('livewire.core.user.show')->extends('livewire-app');
     }
 
-    public function edit()
-    {
-        $this->authorize('update', $this->user);
-        $this->editRecord = true;
-    }
+    // @TODO Remove after confirmation on WP-8 Remove User info Edit
+    // public function edit()
+    // {
+    //     $this->authorize('update', $this->user);
+    //     $this->editRecord = true;
+    // }
 
     /**
      * Delete existing user
      */
-    public function delete()
-    {
-        $this->authorize('delete', $this->user);
+    // public function delete()
+    // {
+    //     $this->authorize('delete', $this->user);
 
-        $this->user->update([
-            'email' => $this->user->email . '+del+'. time()
-        ]);
+    //     $this->user->update([
+    //         'email' => $this->user->email . '+del+'. time()
+    //     ]);
 
-        $this->user->delete();
-        session()->flash('success', 'User deleted !');
+    //     $this->user->delete();
+    //     session()->flash('success', 'User deleted !');
 
-        return redirect()->route('core.user.index');
-    }
+    //     return redirect()->route('core.user.index');
+    // }
 
     public function cancel()
     {
-        $this->editRecord = false;
+        // @TODO Remove after confirmation on WP-8 Remove User info Edit
+        // $this->editRecord = false;
     }
 }

--- a/app/Http/Livewire/Core/User/Traits/FormRequest.php
+++ b/app/Http/Livewire/Core/User/Traits/FormRequest.php
@@ -76,6 +76,7 @@ trait FormRequest
         }
 
         $this->roles = Role::ofAccount(auth()->user()->account_id)
+            ->whereNot('name', 'super-admin-account-'.auth()->user()->account_id)
             ->basicSelect()
             ->get();
     }
@@ -114,7 +115,10 @@ trait FormRequest
         ]);
 
         $this->user->save();
-        $this->user->assignRole($this->selectedRole);
+
+        if($this->selectedRole != 'super-admin-account-'.$this->user->account_id) {
+            $this->user->assignRole($this->selectedRole);
+        }
 
         $this->user->invited_by = auth()->user()->id;
 
@@ -135,20 +139,21 @@ trait FormRequest
     /**
      * Update existing user
      */
-    public function update()
-    {
-        $this->user->abbreviation = $this->getAbbreviation();
+    // @TODO Remove after confirmation on WP-8 Remove User info Edit
+    // public function update()
+    // {
+    //     $this->user->abbreviation = $this->getAbbreviation();
 
-        $this->user->save();
+    //     $this->user->save();
 
-        if ($this->user->roles->first()?->name != $this->selectedRole) {
-            $this->user->roles()->detach();
-            $this->user->assignRole($this->selectedRole);
-        }
+    //     if ($this->user->roles->first()?->name != $this->selectedRole) {
+    //         $this->user->roles()->detach();
+    //         $this->user->assignRole($this->selectedRole);
+    //     }
 
-        $this->editRecord = false;
-        session()->flash('success', 'User updated!');
-    }
+    //     $this->editRecord = false;
+    //     session()->flash('success', 'User updated!');
+    // }
 
     public function closeModal()
     {

--- a/app/Http/Livewire/Order/Index.php
+++ b/app/Http/Livewire/Order/Index.php
@@ -18,11 +18,6 @@ class Index extends Component
         ],
     ];
 
-    public function render()
-    {
-        return $this->renderView('livewire.order.index');
-    }
-
     public function mount()
     {
         $this->account = account();
@@ -35,5 +30,10 @@ class Index extends Component
             ->where('invoicedt', '=', '2022-03-30')
             ->where('whse', 'UTIC')
             ->get();
+    }
+
+    public function render()
+    {
+        return $this->renderView('livewire.order.index');
     }
 }

--- a/app/Http/Livewire/Vehicle/Vehicle/Index.php
+++ b/app/Http/Livewire/Vehicle/Vehicle/Index.php
@@ -38,18 +38,18 @@ class Index extends Component
         ],
     ];
 
-    public function render()
-    {
-        //$this->authorize('viewAny', Account::class);
-
-        return $this->renderView('livewire.vehicle.vehicle.index');
-    }
-
     public function mount()
     {
         $this->account = account();
         $this->vehicle = new Vehicle();
         $this->formInit();
+    }
+
+    public function render()
+    {
+        //$this->authorize('viewAny', Account::class);
+
+        return $this->renderView('livewire.vehicle.vehicle.index');
     }
 
     public function updated($propertyName, $value)

--- a/app/Policies/Core/CustomerPolicy.php
+++ b/app/Policies/Core/CustomerPolicy.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Policies\Core;
+
+use App\Models\Core\Customer;
+use App\Models\Core\User;
+use Illuminate\Auth\Access\Response;
+
+class CustomerPolicy
+{
+    /**
+     * Create a new policy instance.
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    public function before(User $user, $ability)
+    {
+        // @TODO Commented because for admin showing domain error
+        // if ($user->hasRole('master-admin')) {
+        //     return true;
+        // }
+    }
+
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user): bool
+    {
+        return $user->can('customers.view');
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, Customer $customer): bool
+    {
+        abort_if(!$this->hasAccess($user, $customer), 401);
+
+        return $user->can('customers.view');
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user): bool
+    {
+        return $user->can('locations.manage');
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, Customer $customer): bool
+    {
+        abort_if(!$this->hasAccess($user, $customer), 401);
+
+        return $user->can('locations.manage');
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, Customer $customer): bool
+    {
+        abort_if(!$this->hasAccess($user, $customer), 401);
+
+        return $user->can('locations.manage');
+    }
+
+    /**
+     * Determine whether the user can restore the model.
+     */
+    public function restore(User $user, Customer $customer): bool
+    {
+        abort_if(!$this->hasAccess($user, $customer), 401);
+
+        return $user->can('locations.manage');
+    }
+
+    /**
+     * Determine whether the user can permanently delete the model.
+     */
+    public function forceDelete(User $user, Customer $customer): bool
+    {
+        abort_if(!$this->hasAccess($user, $customer), 401);
+
+        return $user->can('locations.manage');
+    }
+
+    //Private functions
+    private function hasAccess(User $user, Customer $customer)
+    {
+        return $user->account_id == $customer->account_id;
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -46,6 +46,7 @@ class AuthServiceProvider extends ServiceProvider
             \App\Models\Core\Account::class => \App\Policies\Core\AccountPolicy::class,
             \App\Models\Core\Location::class => \App\Policies\Core\LocationPolicy::class,
             \App\Models\Core\Module::class => \App\Policies\Core\ModulePolicy::class,
+            \App\Models\Core\Customer::class => \App\Policies\Core\CustomerPolicy::class
         ];
     }
 

--- a/database/seeders/mappings/permissions/core.json
+++ b/database/seeders/mappings/permissions/core.json
@@ -55,7 +55,21 @@
                 "description" : "Can view enabled modules"
             }
         ]
+    },
+    {
+        "group": "Customer",
+        "type": ["master", "account"],
+        "items": [
+            {
+                "name": "customers.view",
+                "label": "View Customers",
+                "description" : "Can view customers"
+            },
+            {
+                "name": "customers.manage",
+                "label": "Manage Customers",
+                "description" : "Can create/update/delete customers"
+            }
+        ]
     }
-
-
 ]

--- a/resources/views/livewire/core/role/partials/view.blade.php
+++ b/resources/views/livewire/core/role/partials/view.blade.php
@@ -4,7 +4,7 @@
 
 
             @can('roles.manage')
-                @if(!$role->is_preset) 
+                @if(!$role->is_preset)
                     <livewire:component.action-button
                         :actionButtons="$actionButtons"
                     >
@@ -12,12 +12,12 @@
             @endcan
             <h3 class="h5 mb-0"><i class="fas fa-bars me-1"></i> Overview</h3>
         </div>
-        
+
         <div class="card-body">
 
             <ul class="list-group list-group-flush">
 
-                <li class="list-group-item d-flex align-items-center justify-content-between px-0 border-bottom">
+                <li class="list-group-item d-flex align-items-center justify-content-between px-0">
                     <div>
                         <h3 class="h6 mb-1">Role Name</h3>
                         <p class="small pe-4">{{ $role->label }}</p>
@@ -40,7 +40,7 @@
                             {{ $permissionGroup["group_name"] }}
                         </button>
                         </h2>
-                        
+
                         <div id="collapse-{{ $group }}" class="accordion-collapse collapse show" aria-labelledby="heading{{ $group }}">
                         <div class="accordion-body">
                             <div class="row">
@@ -53,7 +53,7 @@
                                     <sup><i class="fas fa-question-circle"
                                         data-bs-toggle="tooltip"
                                         data-bs-custom-class="custom-tooltip"
-                                        data-bs-placement="right" 
+                                        data-bs-placement="right"
                                         data-bs-title="{{ $permission->description  }}"></i></sup>
                                     @endif
                                 </div>

--- a/resources/views/livewire/core/user/partials/view.blade.php
+++ b/resources/views/livewire/core/user/partials/view.blade.php
@@ -36,7 +36,7 @@
                     <div>
                 </li>
 
-                <li class="list-group-item d-flex align-items-center justify-content-between px-0 border-bottom">
+                <li class="list-group-item d-flex align-items-center justify-content-between px-0">
                     <div>
                         <h3 class="h6 mb-1">Role</h3>
                         <p class="small pe-4">{{ $user->roles->first()?->label }}</p>


### PR DESCRIPTION
### Commands to Execute
php artisan db:Seed --class=RolePermissionSeeder

### Change Log

1. Added Policy for Customer
2. modified mount and render function order in existing files
3. Removed User Edit and update 
4. Removed Super Admin Role from the select box on User Creation and prevent 'Super Admin' from assigning to any user from Form.


**Note :**
Removal of User Edit and Updated are commented with 
'// @TODO Remove after confirmation on WP-8 Remove User info Edit'
will remove after confirmation